### PR TITLE
Fix Rabbitmq throws err

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ logs
 *.log
 npm-debug.log*
 yarn.lock
-# .env
+.env
 
 # Externals
 external/

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@
  * Module dependencies.
  */
 
-const debug = require('debug')('sttp:server');
+require('dotenv').config();
+const debug = require('debug')('http:server');
 const http = require('http');
 const app = require('./server')
-require('dotenv').config();
 
 /**
  * Get port from environment and store in Express.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "git": "func() { git add . && git commit -m \"$1\" && git push origin HEAD; }; func",
-    "start": "NODE_ENV=production && node index.js",
-    "dev": "NODE_ENV=development && nodemon --legacy-watch  index.js",
+    "start": "NODE_ENV=production node index.js",
+    "dev": "NODE_ENV=development nodemon --legacy-watch index.js",
     "test": "npm run test"
   },
   "keywords": [


### PR DESCRIPTION
RabbitMQ was causing the app to crash because it was not seeing the `process.env.AMQP` variable.
This was caused by `dotenv` being required after `server.js` in `index.js` instead of before it